### PR TITLE
Implement server caps by environment

### DIFF
--- a/.github/workflows/build_stage.yml
+++ b/.github/workflows/build_stage.yml
@@ -104,4 +104,4 @@ jobs:
         template: cloudformation/release_site/top.yaml
         capabilities: "CAPABILITY_NAMED_IAM,CAPABILITY_IAM"
         no-fail-on-empty-changeset: "1"
-        parameter-overrides: environment=stage
+        parameter-overrides: environment=stage,MaxServerCount=10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,4 +86,4 @@ jobs:
         template: cloudformation/release_site/top.yaml
         capabilities: "CAPABILITY_NAMED_IAM,CAPABILITY_IAM"
         no-fail-on-empty-changeset: "1"
-        parameter-overrides: environment=production
+        parameter-overrides: environment=production,MaxServerCount=25

--- a/cloudformation/tetraforce/api.yaml
+++ b/cloudformation/tetraforce/api.yaml
@@ -30,6 +30,10 @@ Parameters:
   TaskSecurityGroupId:
     Description: ID of the security group for running tasks
     Type: String
+  MaxServerCount:
+    Description: Max numbers of ECS tasks that can run in the cluster
+    Type: String
+    Default: "2"
 
 Resources:
 
@@ -117,6 +121,7 @@ Resources:
           SERVERLIST_TABLE: !Ref ServerlistTable
           VPC_ID: !Ref VpcId
           TASK_SECURITY_GROUP: !Ref TaskSecurityGroupId
+          MAX_SERVER_COUNT: !Ref MaxServerCount
   # Grant permission to API Gateway
   CreateTaskLambdaPermission:
     Type: AWS::Lambda::Permission

--- a/cloudformation/tetraforce/top.yaml
+++ b/cloudformation/tetraforce/top.yaml
@@ -48,6 +48,14 @@ Parameters:
     Description: The AWS CloudWatch log group to output logs to.
     Default: "/ecs/tetraforce"
 
+  #------------
+  # Environment
+  #------------
+  MaxServerCount:
+    Description: Max numbers of ECS tasks that can run in the cluster
+    Type: String
+    Default: "2"
+
 Resources:
 
   IAM:
@@ -110,3 +118,4 @@ Resources:
         ServerlistTable: !GetAtt Persistence.Outputs.ServerlistTable
         VpcId: !Ref VpcId
         TaskSecurityGroupId: !GetAtt TaskSecurityGroup.GroupId
+        MaxServerCount: !Ref MaxServerCount

--- a/lambda/create_server/lambda_function.py
+++ b/lambda/create_server/lambda_function.py
@@ -17,7 +17,7 @@ table = dynamodb.Table(os.environ.get("SERVERLIST_TABLE"))
 ec2 = boto3.resource('ec2')
 vpc = ec2.Vpc(os.environ.get("VPC_ID"))
 
-max_server_count = os.environ.get("MAX_SERVER_COUNT", 2)
+max_server_count = int(os.environ.get("MAX_SERVER_COUNT", 2))
 
 def lambda_handler(event, context):
     

--- a/lambda/create_server/lambda_function.py
+++ b/lambda/create_server/lambda_function.py
@@ -17,6 +17,8 @@ table = dynamodb.Table(os.environ.get("SERVERLIST_TABLE"))
 ec2 = boto3.resource('ec2')
 vpc = ec2.Vpc(os.environ.get("VPC_ID"))
 
+max_server_count = os.environ.get("MAX_SERVER_COUNT", 2)
+
 def lambda_handler(event, context):
     
     server_name = ""
@@ -30,6 +32,10 @@ def lambda_handler(event, context):
     # Generate unique server name if not name is provided
     if server_name == "":
         server_name = generate_unique_name(table)
+
+    # Verify that only a desired amount of servers are running
+    if tasks_at_max(max_server_count):
+        return build_response("Servers are at max capacity! Please contact environment admins!", False)
     
     response = {}
     
@@ -89,6 +95,45 @@ def lambda_handler(event, context):
     else:
         logger.error(response)
         return unknown_error_response()
+
+
+def tasks_at_max(num):
+    number_of_tasks_found = 0
+
+    # Get first list of cluser state
+    ecs_response = ecs.list_tasks(
+        cluster=os.environ.get("CLUSTER"),
+        launchType="FARGATE"
+        )
+
+    # Update next token
+    next_token = None
+    if "nextToken" in ecs_response:
+        next_token = ecs_response["nextToken"]
+
+    # Get first list's number of tasks
+    if "taskArns" in ecs_response:
+        number_of_tasks_found = len(ecs_response["taskArns"])
+
+    # While there are more tasks & return tasks <= desired number of tasks
+    while next_token != None and number_of_tasks_found <= num:
+        ecs_response = ecs.list_tasks(
+            cluster=os.environ.get("CLUSTER"),
+            launchType="FARGATE",
+            nextToken=next_token
+            )
+        
+        # Update next token
+        if "nextToken" in ecs_response:
+            next_token = ecs_response["nextToken"]
+        else:
+            next_token = None
+        
+        # Update number of tasks
+        if "taskArns" in ecs_response:
+            number_of_tasks_found = number_of_tasks_found + len(ecs_response["taskArns"])
+
+    return number_of_tasks_found >= num
 
 def unknown_error_response():
     return build_response("An unknown error occured!", False)


### PR DESCRIPTION
Because we are creating and deleting server tasks ourselves, I thought it'd be a good idea to cap the number of servers per environment.

This allows us to do two major things:
- Limit number of tasks running in development environments (e.g. severs that don't close themselves)
- More control over costs

Closes #31 